### PR TITLE
Upgrade to Java 21 and MockK compatibility

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -67,11 +67,11 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
+        sourceCompatibility = JavaVersion.VERSION_21
+        targetCompatibility = JavaVersion.VERSION_21
     }
     kotlinOptions {
-        jvmTarget = "11"
+        jvmTarget = "21"
     }
 
     buildFeatures {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,7 +16,7 @@ koin = "2.2.2"
 kotlin = "2.1.10"
 ksp = "2.1.10-1.0.29"
 material = "1.12.0"
-mockk = "1.10.2"
+mockk = "1.13.10"
 
 [libraries]
 androidx-activity = { group = "androidx.activity", name = "activity", version.ref = "activity" }


### PR DESCRIPTION
- Updated Java compile and target compatibility to Java 21
- Updated Kotlin JVM target to 21
- Updated MockK from 1.10.2 to 1.13.10 to support Java 21
- Verified tests run without warnings using the new JDK